### PR TITLE
Feature/docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,64 @@
+# Environment files
+.env
+.env.local
+.env.*
+*.env
+
+# Version control
+.git
+.gitignore
+.gitattributes
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.py[cod]
+*$py.class
+.pytest_cache
+.coverage
+htmlcov/
+.tox/
+.nox/
+.hypothesis/
+
+# Virtual Environment
+venv/
+env/
+ENV/
+.venv
+.env
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+*.sublime-workspace
+*.sublime-project
+
+# Build and dist directories
+build/
+dist/
+*.egg-info/
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+
+# Local development specific
+docker-compose.override.yml
+docker-compose.*.yml
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# Test files
+test/
+tests/

--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,5 @@ GOOGLE_API_KEY=
 # Other configurations
 CONVERSATION_LOG_PATH=logs/conversation.json  # Path to save conversation logs
 
+BROWSER_HEADLESS=false
 # Other configurations... 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,86 +1,93 @@
-# Use Playwright's Python image as base with Python 3.11
-FROM mcr.microsoft.com/playwright/python:v1.41.0-focal
-
-# Set working directory
-WORKDIR /app
-
-# Install Python 3.11 and required system dependencies
-RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get update && \
-    apt-get install -y \
-    python3.11 \
-    python3.11-distutils \
-    python3.11-dev \
-    python3.11-venv \
-    ffmpeg \
-    imagemagick \
-    fonts-dejavu \
-    ttf-dejavu \
-    fonts-liberation \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
-    && update-alternatives --set python3 /usr/bin/python3.11 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Configure ImageMagick policy to allow GIF operations
-RUN sed -i 's/rights="none" pattern="PDF"/rights="read|write" pattern="PDF"/' /etc/ImageMagick-6/policy.xml && \
-    sed -i 's/<policy domain="coder" rights="none" pattern="PS" \/>/<policy domain="coder" rights="read|write" pattern="PS" \/>/' /etc/ImageMagick-6/policy.xml && \
-    sed -i 's/<policy domain="coder" rights="none" pattern="XPS" \/>/<policy domain="coder" rights="read|write" pattern="XPS" \/>/' /etc/ImageMagick-6/policy.xml
-
-# Create font cache directory and update font cache
-RUN mkdir -p /usr/share/fonts/truetype && \
-    fc-cache -f -v
-
-# Create and switch to a non-root user
-RUN useradd -m -s /bin/bash appuser && \
-    chown -R appuser:appuser /app
-
-# Create and activate virtual environment
-RUN python3.11 -m venv /app/venv && \
-    chown -R appuser:appuser /app/venv
-ENV PATH="/app/venv/bin:$PATH"
-ENV VIRTUAL_ENV="/app/venv"
-
-# Install pip in the virtual environment
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    /app/venv/bin/python3.11 get-pip.py && \
-    rm get-pip.py
-
-# Set history directory environment variable
-ENV HISTORY_DIR=/testronai/history
-
-# Copy requirements file
-COPY --chown=appuser:appuser requirements.txt .
-
-# Install Python dependencies as appuser
-RUN su appuser -c "/app/venv/bin/pip install --no-cache-dir -r requirements.txt"
-
-# Copy the entire project
-COPY --chown=appuser:appuser . .
-
-# Expose port 8080 for Railway
-EXPOSE 8080
+# Use Python 3.11 as base image
+FROM python:3.11-slim
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
-ENV STREAMLIT_SERVER_PORT=8080
+ENV HISTORY_DIR=/app/history
+ENV DISPLAY=:99
+ENV STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
+ENV STREAMLIT_SERVER_HEADLESS=true
 ENV STREAMLIT_SERVER_ADDRESS=0.0.0.0
+ENV STREAMLIT_SERVER_PORT=8080
+ENV STREAMLIT_SERVER_RUN_ON_SAVE=true
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+ENV CHROME_PATH=/ms-playwright/chromium-*/chrome-linux/chrome
+ENV BROWSER_USE_LOGGING_LEVEL=info
+ENV ANONYMIZED_TELEMETRY=false
+ENV RESOLUTION=1920x1080x24
+ENV RESOLUTION_WIDTH=1920
+ENV RESOLUTION_HEIGHT=1080
+ENV BROWSER_HEADLESS=true
 
-# Create an entrypoint script
-COPY <<'EOF' /app/entrypoint.sh
-#!/bin/bash
-# Create history directory with root permissions
-mkdir -p $HISTORY_DIR
-# Set permissions for appuser
-chown -R appuser:appuser $HISTORY_DIR
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    wget \
+    netcat-traditional \
+    gnupg \
+    curl \
+    unzip \
+    xvfb \
+    libgconf-2-4 \
+    libxss1 \
+    libnss3 \
+    libnspr4 \
+    libasound2 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    xdg-utils \
+    fonts-liberation \
+    dbus \
+    xauth \
+    xvfb \
+    python3-numpy \
+    fontconfig \
+    fonts-dejavu \
+    fonts-dejavu-core \
+    fonts-dejavu-extra \
+    ffmpeg \
+    imagemagick \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Switch to appuser and run the app with proper environment
-exec su appuser -c "/app/venv/bin/python3.11 -m streamlit run src/app.py"
-EOF
+# Fix ImageMagick policy to allow PDF operations
+RUN sed -i 's/rights="none" pattern="PDF"/rights="read|write" pattern="PDF"/' /etc/ImageMagick-6/policy.xml
 
-RUN chmod +x /app/entrypoint.sh
+# Update font cache
+RUN mkdir -p /usr/share/fonts/truetype && \
+    fc-cache -f -v
 
-# Command to run the app
-CMD ["/app/entrypoint.sh"] 
+# Set working directory and create necessary directories
+WORKDIR /app
+RUN mkdir -p /app/history
+
+# Copy requirements file
+COPY requirements.txt .
+
+# Install Python dependencies and Playwright with system dependencies AS ROOT
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir playwright==1.49.0 && \
+    playwright install --with-deps chromium && \
+    playwright install-deps
+
+# Create and switch to a non-root user
+RUN useradd -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app && \
+    chown -R appuser:appuser /ms-playwright
+
+# Switch to non-root user
+USER appuser
+
+# Copy application files
+COPY --chown=appuser:appuser . .
+
+# Command to run the application
+CMD ["python", "-m", "streamlit", "run", "src/app.py", "--server.port", "8080", "--server.address", "0.0.0.0"] 

--- a/Readme.md
+++ b/Readme.md
@@ -91,6 +91,37 @@ streamlit run src/app.py
 
 The application will be available at `http://localhost:8501` by default.
 
+## Docker Execution
+
+Promptwright can be run as a Docker container, with Chrome browser and Playwright pre-installed in the image.
+
+### Docker Setup
+
+1. Build the Docker image:
+   ```bash
+   docker build -t promptwright:0.1 .
+   ```
+
+2. Run the container:
+   ```bash
+   docker run -p 8080:8080 --name promptwright_container promptwright:0.1
+   ```
+
+3. Access the application at `http://localhost:8080`
+
+### Notes
+- The Docker image includes:
+  - Chrome browser
+  - Playwright with all dependencies
+  - Required system libraries
+  - Python environment
+- All browser automation executes inside the container
+- No need to install Chrome or Playwright on your host machine
+- To rebuild and restart in one command:
+  ```bash
+  docker rm -f promptwright_container || true && docker build -t promptwright:0.1 . && docker run -p 8080:8080 --name promptwright_container promptwright:0.1
+  ```
+
 ## Using Promptwright
 
 1. Configure your preferences in the sidebar:

--- a/src/services/browser_task_runner.py
+++ b/src/services/browser_task_runner.py
@@ -53,7 +53,6 @@ class BrowserTaskRunner:
         
         # Debug logging
         logger.debug("BrowserTaskRunner initialized")
-
     def _get_browser_config(self) -> BrowserConfig:
         """
         Configure and return browser settings based on latest configuration
@@ -64,8 +63,16 @@ class BrowserTaskRunner:
         
         logger.debug(f"Configuring browser with type: {self.browser_type}")
         
+        # Get headless mode from environment variable, default to True
+        headless_mode = self.config_manager.get_config('BROWSER_HEADLESS', 'true').lower() == 'true'
+        
+        # Add prominent console log for headless mode
+        logger.info("\n" + "="*50)
+        logger.info(f"🎭 Browser Headless Mode: {'ON' if headless_mode else 'OFF'}")
+        logger.info("="*50 + "\n")
+        
         config_params = {
-            'headless': False,
+            'headless': headless_mode,
             'disable_security': True,
             'highlight_elements': False
         }
@@ -73,6 +80,7 @@ class BrowserTaskRunner:
         logger.info("\n=== Browser Configuration Details ===")
         logger.info(f"Browser Type: {self.browser_type}")
         logger.info(f"Cloud Provider: {self.cloud_provider}")
+        logger.info(f"Headless Mode: {headless_mode}")
         logger.debug(f"Initial config_params: {config_params}")
         
         if self.browser_type == 'remote':


### PR DESCRIPTION
# Add Docker Support

## Description
Added Docker support to run Promptwright in a containerized environment with all dependencies pre-installed.

### Key Changes
- Added Dockerfile with:
  - Python 3.11 base image
  - Chrome browser and system dependencies
  - Playwright installation with browser dependencies
  - Non-root user setup for security
- Added Docker setup documentation in README.md
- Added Docker commands for building and running
- Configured container to expose port 8080

### Benefits
- Simplified deployment with all dependencies packaged
- Consistent environment across different systems
- No need to install Chrome/Playwright locally
- Improved security with non-root user execution
- Easy rebuild and restart commands

### Testing Done
- Built and tested image locally
- Verified browser automation works in container
- Tested headless mode configuration
- Validated file permissions and user access
- Confirmed port mapping and accessibility

### How to Test
1. Build image:
```bash
docker build -t promptwright:0.1 .
```

2. Run container:
```bash
docker run -p 8080:8080 --name promptwright_container promptwright:0.1
```

3. Access app at http://localhost:8080

### Notes
- Container runs in headless mode by default
- All browser automation executes inside container
- Chrome and Playwright are pre-installed in image